### PR TITLE
follow XDG specification for config files

### DIFF
--- a/utility/fileUtil.py
+++ b/utility/fileUtil.py
@@ -2,7 +2,10 @@ import os
 from os.path import expanduser
 
 # Global Section Variables
-PATH = expanduser("~") + "/.config/tvdoon/"
+try:
+    PATH = os.environ["XDG_CONFIG_HOME"] + "/tvdoon/"
+except KeyError:
+    PATH = expanduser("~") + "/.config/tvdoon/"
 
 def checkConfExist():
     # create conf directory


### PR DESCRIPTION
minor nitpick: the application should follow [the xdg base directory specification](https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html)